### PR TITLE
Fixed Dockerfile to deal with bad XRTM commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,21 +10,27 @@ FROM quay.io/jupyter/julia-notebook:latest
 ENV JULIA_NUM_THREADS=3
 ENV OMP_NUM_THREADS=1
 
-RUN conda install -y conda-forge::make flex gfortran libopenblas
+RUN conda install -y conda-forge::make flex gfortran gxx libopenblas binutils patch
 
 RUN git clone https://github.com/gmcgarragh/bindx2 bindx2 && cd bindx2 \
     && cp make.inc.example make.inc && make
  
-RUN git clone https://github.com/gmcgarragh/xrtm.git xrtm && cd xrtm \
-    && cp make.inc.example make.inc && make
-
-#RUN git clone https://github.com/PeterSomkuti/xrtm.git xrtm && cd xrtm \
+#RUN git clone https://github.com/gmcgarragh/xrtm.git xrtm && cd xrtm \
 #    && cp make.inc.example make.inc && make
 
-    
+RUN git clone https://github.com/PeterSomkuti/xrtm.git xrtm && cd xrtm \
+    && git checkout b3aeace && cp make.inc.example make.inc
+
+# Patch XRTM makefile
+COPY make_xrtm.patch xrtm/
+RUN cd xrtm && patch < make_xrtm.patch
+# build (making the doc from tex will fail, but that's fine..)
+RUN cd xrtm && make; exit 0
+
 
 #### Install Julia Packages
 RUN julia -e 'using Pkg; Pkg.add(["Plots", "LaTeXStrings", "ArgParse", "Dates", "DocStringExtensions", "HDF5", "Interpolations", "LinearAlgebra", "Logging", "LoopVectorization", "Printf", "ProgressMeter", "Statistics", "StatsBase", "Unitful"])'
+
 # todo: switch to use toml file with julia 
 #RUN git clone https://github.com/US-GHG-Center/RetrievalToolbox.jl && \
 #    julia --project=RetrievalToolbox.jl -e 'using Pkg; Pkg.instantiate()'

--- a/make_xrtm.patch
+++ b/make_xrtm.patch
@@ -1,0 +1,18 @@
+--- xrtm/make.inc.example       2025-05-06 13:37:58.926801906 +0000
++++ xrtm/make.inc       2025-05-06 13:42:44.744015569 +0000
+@@ -57,7 +57,7 @@
+ else
+ 
+     # LAPACK
+-    LINKS        += $(HOME)/opt/lapack/liblapack.a
++    #LINKS        += $(HOME)/opt/lapack/liblapack.a
+ 
+     # BLAS
+ 
+@@ -65,7 +65,7 @@
+     #LINKS        += ${HOME}/opt/lapack/libblas.a
+ 
+     # OpenBLAS
+-    LINKS        += ${HOME}/opt/openblas/lib/libopenblas.a
++    LINKS        += /opt/conda/lib/libopenblas.so.0
+ endif


### PR DESCRIPTION
This new Dockerfile pulls a specific commit of XRTM from my repo. Still needs testing with RetrievalToolbox, but at least this image builds XRTM successfully. Also the makefile patch is now added to the repo, rather than clumsily being part of the Dockerfile.

Some of the extra packages needed are pulled through conda, but could likely be also done via apt-get.