### PR TITLE
Changes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ RUN cd xrtm && make; exit 0
 
 
 #### Install Julia Packages
-RUN julia -e 'using Pkg; Pkg.add(["Plots", "LaTeXStrings", "ArgParse", "Dates", "DocStringExtensions", "HDF5", "Interpolations", "LinearAlgebra", "Logging", "LoopVectorization", "Printf", "ProgressMeter", "Statistics", "StatsBase", "Unitful"]); Pkg.precompile()'
+RUN julia -e 'using Pkg; Pkg.add(["Plots", "LaTeXStrings", "ArgParse", "Dates", "DocStringExtensions", "HDF5", "Interpolations", "LinearAlgebra", "Logging", "LoopVectorization", "Printf", "ProgressMeter", "Statistics", "StatsBase", "Unitful", "AWS", "AWSS3"]); Pkg.precompile()'
+
+# Deactivate "download" button
+RUN jupyter-labextension disable @jupyterlab/docmanager-extension:download && jupyter-labextension disable @jupyterlab/filebrowser-extension:download && jupyter-labextension lock
 
 # todo: switch to use toml file with julia 
 #RUN git clone https://github.com/US-GHG-Center/RetrievalToolbox.jl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,17 @@ FROM quay.io/jupyter/julia-notebook:latest
 ## Install Dependencies
 #RUN apt update && apt install -y flex gfortran build-essential libopenblas-dev liblapack-dev
 
-#USER jovyan
+USER jovyan
 ## Env Variables
 ENV JULIA_NUM_THREADS=3
 ENV OMP_NUM_THREADS=1
+ENV XRTM_PATH=/home/jovyan/xrtm
 
 RUN conda install -y conda-forge::make flex gfortran gxx libopenblas binutils patch
 
 RUN git clone https://github.com/gmcgarragh/bindx2 bindx2 && cd bindx2 \
     && cp make.inc.example make.inc && make
- 
+
 #RUN git clone https://github.com/gmcgarragh/xrtm.git xrtm && cd xrtm \
 #    && cp make.inc.example make.inc && make
 
@@ -29,7 +30,7 @@ RUN cd xrtm && make; exit 0
 
 
 #### Install Julia Packages
-RUN julia -e 'using Pkg; Pkg.add(["Plots", "LaTeXStrings", "ArgParse", "Dates", "DocStringExtensions", "HDF5", "Interpolations", "LinearAlgebra", "Logging", "LoopVectorization", "Printf", "ProgressMeter", "Statistics", "StatsBase", "Unitful"])'
+RUN julia -e 'using Pkg; Pkg.add(["Plots", "LaTeXStrings", "ArgParse", "Dates", "DocStringExtensions", "HDF5", "Interpolations", "LinearAlgebra", "Logging", "LoopVectorization", "Printf", "ProgressMeter", "Statistics", "StatsBase", "Unitful"]); Pkg.precompile()'
 
 # todo: switch to use toml file with julia 
 #RUN git clone https://github.com/US-GHG-Center/RetrievalToolbox.jl && \


### PR DESCRIPTION
This updated changes the build location of the third-party library XRTM and disables the download button in the Jupyterlab interface (for now, we might not want demo users to be able download some of the auxiliary data).